### PR TITLE
Some fixes for the redis role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,7 @@
 dependencies:
 - role: 'davidwittman.redis'
   vars:
+    redis_service_name: redis
     redis_dir: /var/lib/redis
     redis_pidfile: /var/run/redis/redis-server.pid
     redis_logfile: /var/log/redis/redis-server.log

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,1 +1,6 @@
 ---
+- name: Allow read permissions on redis install dir
+  file: dest=/opt/redis owner=root group=redis mode=0755 state=directory recurse=yes
+
+- name: Assert redis is started
+  service: name=redis state=started

--- a/test/integration/default/serverspec/redis_spec.rb
+++ b/test/integration/default/serverspec/redis_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Redis' do
-  describe service('redis_6379') do
+  describe service('redis') do
     it { should be_enabled }
     it { should be_running }
   end


### PR DESCRIPTION
Update directory permissions on redis install dir so redis starts up properly. This also lets other users run redis-cli.